### PR TITLE
Stripping years from titles

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "SONARR_IP": "http://192.168.204.63:9595",
-    "API_KEY": "7270f10693e7462f8754d60326cc2e8a",
+    "API_KEY": "e9baeecab0c04a3182cdfdc8d3e41a52",
     "TMDB_API_KEY": "b3ef4c7ca4fec1df3335c897e550398b",
     "PROFILE_1_NAME": "upgraded",
     "PROFILE_2_NAME": "downgraded",


### PR DESCRIPTION
These changes use regex to strip years from titles. This fixes shows with names such as "Invincible (2021)" not matching the show in TMDB.