### PR TITLE
Changed logic for continuing shows

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "TMDB_API_KEY": "b3ef4c7ca4fec1df3335c897e550398b",
     "PROFILE_1_NAME": "upgraded",
     "PROFILE_2_NAME": "downgraded",
-    "DAYS_THRESHOLD": 40,
+    "DAYS_THRESHOLD": 60,
     "RATING_THRESHOLD": 7.5,
     "PROFILE_1_GENRES": ["Drama", "Crime", "Documentary"],
     "PROFILE_2_GENRES": ["Comedy", "Animation"],

--- a/downgraderr.py
+++ b/downgraderr.py
@@ -133,9 +133,13 @@ def main():
             last_airing_date = datetime.min  # Set to min date if no last airing date
 
         # Determine profile based on conditions
-        if (last_airing_date < threshold_date and status.lower() != 'continuing') or tmdb_rating < RATING_THRESHOLD or (any(genre in genres for genre in PROFILE_2_GENRES) and not any(genre in genres for genre in PROFILE_1_GENRES)):
+        if ((last_airing_date < threshold_date and status.lower() != 'continuing') or 
+            tmdb_rating < RATING_THRESHOLD or 
+            (any(genre in genres for genre in PROFILE_2_GENRES) and not any(genre in genres for genre in PROFILE_1_GENRES))):
             profile_id = profile_2_id
-        elif status.lower() == 'continuing' and tmdb_rating >= RATING_THRESHOLD and any(genre in genres for genre in PROFILE_1_GENRES) and not any(genre in genres for genre in PROFILE_2_GENRES):
+        elif (status.lower() == 'continuing' and 
+              tmdb_rating >= RATING_THRESHOLD and 
+              any(genre in genres for genre in PROFILE_1_GENRES)):
             profile_id = profile_1_id
         else:
             profile_id = profile_2_id  # Default to profile 2 if no other condition is met


### PR DESCRIPTION
Changed the logic for continuing shows.

Profile 1:
-The show is continuing,
-The show is rated above the threshold,
-The show has a genre listed in the profile 1 genre list,

Profile 2:
-The last airing date is older than the threshold and the show is not continuing,
-The rating is below the threshold,
-The show has a genre listed in the profile 2 genre list and does not have a genre listed in the profile 1 genre list.