### PR TITLE
Seperate thresholds for 4k and 1080p

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,12 +2,21 @@
     "SONARR_IP": "http://192.168.204.63:9595",
     "API_KEY": "e9baeecab0c04a3182cdfdc8d3e41a52",
     "TMDB_API_KEY": "b3ef4c7ca4fec1df3335c897e550398b",
+    "CACHE_DIR": "ratings_cache",
+
     "PROFILE_4k_NAME": "4k",
-    "PROFILE_720p_NAME": "720p",
+    "PROFILE_4k_GENRES": ["Action", "Drama", "Crime", "Documentary", "Science Fiction", "Fantasy"],
+    "RATING_THRESHOLD_4K": 8.0,
+
+    
     "PROFILE_1080p_NAME": "1080p",
-    "DAYS_THRESHOLD": 30,
-    "RATING_THRESHOLD": 7.5,
-    "PROFILE_4k_GENRES": ["Action", "Drama", "Crime", "Documentary", "Science Fiction"],
+    "RATING_THRESHOLD_1080P": 7.0,
+
+    "PROFILE_720p_NAME": "720p",
     "PROFILE_720p_GENRES": ["Comedy", "Animation"],
-    "CACHE_DIR": "ratings_cache"
+
+    "DAYS_THRESHOLD": 30
+
+    
+
 }

--- a/downgraderr.py
+++ b/downgraderr.py
@@ -18,7 +18,8 @@ PROFILE_4k_NAME = config.get('PROFILE_4k_NAME')
 PROFILE_720p_NAME = config.get('PROFILE_720p_NAME')
 PROFILE_1080p_NAME = config.get('PROFILE_1080p_NAME')
 DAYS_THRESHOLD = config.get('DAYS_THRESHOLD')
-RATING_THRESHOLD = config.get('RATING_THRESHOLD')
+RATING_THRESHOLD_1080P = config.get('RATING_THRESHOLD_1080P')
+RATING_THRESHOLD_4K = config.get('RATING_THRESHOLD_4K')
 PROFILE_4k_GENRES = config.get('PROFILE_4k_GENRES')
 PROFILE_720p_GENRES = config.get('PROFILE_720p_GENRES')
 CACHE_DIR = config.get('CACHE_DIR')
@@ -137,7 +138,7 @@ def main():
 
         # Determine profile based on conditions
         if (status.lower() == 'ended' and 
-              tmdb_rating >= RATING_THRESHOLD and 
+              tmdb_rating >= RATING_THRESHOLD_1080P and 
               any(genre in genres for genre in PROFILE_4k_GENRES)):
             profile_id = profile_1080p_id
         elif (status.lower() == 'ended' and 
@@ -145,11 +146,15 @@ def main():
               any(genre in genres for genre in PROFILE_4k_GENRES)):
             profile_id = profile_1080p_id
         elif (status.lower() == 'continuing' and 
-              tmdb_rating >= RATING_THRESHOLD and
+              tmdb_rating >= RATING_THRESHOLD_4K and
               any(genre in genres for genre in PROFILE_4k_GENRES)):
             profile_id = profile_4k_id
+        elif (status.lower() == 'continuing' and 
+              tmdb_rating >= RATING_THRESHOLD_1080P and
+              any(genre in genres for genre in PROFILE_4k_GENRES)):
+            profile_id = profile_1080p_id
         elif ((last_airing_date > threshold_date and status.lower() == 'ended') or 
-              tmdb_rating < RATING_THRESHOLD or 
+              tmdb_rating < RATING_THRESHOLD_1080P or 
               (any(genre in genres for genre in PROFILE_720p_GENRES) and not any(genre in genres for genre in PROFILE_4k_GENRES))):
             profile_id = profile_720p_id
         else:


### PR DESCRIPTION
It was hard to appropriately grade between 4k/1080p/720p using a single threshold, so now it's been split. A rating of 7.5 or 8.0 kinda worked, but a default threshold of 8.0 as a requirement for 4k and 7.0 for 1080p works much better.